### PR TITLE
fix "unable to location global" error when packaging with parcel and webpack

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-const fetch = require('node-fetch').default;
+global.fetch || (global.fetch = require('node-fetch').default);
 const bip39 = require('bip39');
 const bip32 = require('bip32');
 const bech32 = require('bech32');


### PR DESCRIPTION
Uses native fetch when available and node-fetch when not available.