### PR TITLE
added fix for bad signature based on how amino serializes json

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,12 @@ Cosmos.prototype.sign = function(stdSignMsg, ecpairPriv, modeType = "sync") {
 	// The supported return types includes "block"(return after tx commit), "sync"(return after CheckTx) and "async"(return right away).
 	let signMessage = new Object;
 	signMessage = stdSignMsg.json;
-	const hash = crypto.createHash('sha256').update(JSON.stringify(sortObject(signMessage))).digest('hex');
+	const json = JSON.stringify(sortObject(signMessage))
+		.replace(/&/g, '\\u0026')
+		.replace(/</g, '\\u003c')
+		.replace(/>/g, '\\u003e')
+
+	const hash = crypto.createHash('sha256').update(json).digest('hex');
 	const buf = Buffer.from(hash, 'hex');
 	let signObj = secp256k1.sign(buf, ecpairPriv);
 	var signatureBase64 = Buffer.from(signObj.signature, 'binary').toString('base64');


### PR DESCRIPTION
I have found an issue with signing messages using the cosmosjs library due to how Amino does JSON serialization.  For some reason Amino converts three characters (&<>) to unicode strings during serialization.  Since I and cosmosjs are using JSON serialization to create signing bytes the mismatch causes signing errors when these symbols are used in the message.  

This substitution allows for all standard ascii characters to be used.  I have run this through our 140 tests and it works fine with our library.

Please let me know if you need any additional info.

